### PR TITLE
fix(game): 코인 부족 시 부활 버튼 숨김 처리 (#117)

### DIFF
--- a/src/components/game/RevivalButton.test.tsx
+++ b/src/components/game/RevivalButton.test.tsx
@@ -54,6 +54,38 @@ describe('RevivalButton — 정상 흐름', () => {
   })
 })
 
+// ── canRevive=false → null 반환 ───────────────────────────────────────────────
+
+describe('RevivalButton — canRevive=false → null', () => {
+  it('coinBalance=4 → renders nothing', () => {
+    const { queryByRole } = render(
+      <RevivalButton {...defaultProps} coinBalance={4} />
+    )
+    expect(queryByRole('button')).toBeNull()
+  })
+
+  it('coinBalance=0 → renders nothing', () => {
+    const { queryByRole } = render(
+      <RevivalButton {...defaultProps} coinBalance={0} />
+    )
+    expect(queryByRole('button')).toBeNull()
+  })
+
+  it('revivalUsed=true → renders nothing', () => {
+    const { queryByRole } = render(
+      <RevivalButton {...defaultProps} revivalUsed={true} />
+    )
+    expect(queryByRole('button')).toBeNull()
+  })
+
+  it('revivalUsed=true && coinBalance>=5 → renders nothing', () => {
+    const { queryByRole } = render(
+      <RevivalButton {...defaultProps} revivalUsed={true} coinBalance={10} />
+    )
+    expect(queryByRole('button')).toBeNull()
+  })
+})
+
 // ── 엣지 케이스 ───────────────────────────────────────────────────────────────
 
 describe('RevivalButton — 엣지 케이스', () => {
@@ -64,60 +96,17 @@ describe('RevivalButton — 엣지 케이스', () => {
     expect(getByRole('button')).not.toBeDisabled()
   })
 
-  it('경계값: coinBalance=4 (1 부족) → disabled + "코인이 부족합니다 (현재 4개)"', () => {
-    const { getByRole, getByText } = render(
+  it('경계값: coinBalance=4 (1 부족) → 렌더링 없음', () => {
+    const { queryByRole } = render(
       <RevivalButton {...defaultProps} coinBalance={4} />
     )
-    expect(getByRole('button')).toBeDisabled()
-    expect(getByText('코인이 부족합니다 (현재 4개)')).toBeTruthy()
-  })
-
-  it('경계값: coinBalance=0 → disabled + "코인이 부족합니다 (현재 0개)"', () => {
-    const { getByRole, getByText } = render(
-      <RevivalButton {...defaultProps} coinBalance={0} />
-    )
-    expect(getByRole('button')).toBeDisabled()
-    expect(getByText('코인이 부족합니다 (현재 0개)')).toBeTruthy()
-  })
-
-  it('revivalUsed=true && coinBalance>=5 → revivalUsed 우선 ("이미 부활을 사용했습니다")', () => {
-    const { getByText, queryByText } = render(
-      <RevivalButton {...defaultProps} revivalUsed={true} coinBalance={10} />
-    )
-    expect(getByText('이미 부활을 사용했습니다')).toBeTruthy()
-    expect(queryByText(/코인이 부족합니다/)).toBeNull()
+    expect(queryByRole('button')).toBeNull()
   })
 })
 
 // ── 에러 처리 ─────────────────────────────────────────────────────────────────
 
 describe('RevivalButton — 에러 처리', () => {
-  it('revivalUsed=true → disabled + "이미 부활을 사용했습니다"', () => {
-    const { getByRole, getByText } = render(
-      <RevivalButton {...defaultProps} revivalUsed={true} />
-    )
-    expect(getByRole('button')).toBeDisabled()
-    expect(getByText('이미 부활을 사용했습니다')).toBeTruthy()
-  })
-
-  it('disabled 상태(revivalUsed=true)에서 pointerDown → onRevive 미호출', () => {
-    const onRevive = vi.fn()
-    const { getByRole } = render(
-      <RevivalButton {...defaultProps} revivalUsed={true} onRevive={onRevive} />
-    )
-    fireEvent.pointerDown(getByRole('button'))
-    expect(onRevive).not.toHaveBeenCalled()
-  })
-
-  it('disabled 상태(coinBalance<5)에서 pointerDown → onRevive 미호출', () => {
-    const onRevive = vi.fn()
-    const { getByRole } = render(
-      <RevivalButton {...defaultProps} coinBalance={4} onRevive={onRevive} />
-    )
-    fireEvent.pointerDown(getByRole('button'))
-    expect(onRevive).not.toHaveBeenCalled()
-  })
-
   it('isProcessing=true 상태에서 pointerDown → onRevive 미호출', () => {
     const onRevive = vi.fn()
     const { getByRole } = render(

--- a/src/components/game/RevivalButton.tsx
+++ b/src/components/game/RevivalButton.tsx
@@ -9,14 +9,7 @@ interface RevivalButtonProps {
 
 export function RevivalButton({ coinBalance, revivalUsed, isProcessing, onRevive }: RevivalButtonProps): React.ReactElement | null {
   const canRevive = !revivalUsed && coinBalance >= 5
-
-  // 비활성 이유 결정 (PRD 7절·12절 규정 문구)
-  const disabledReason: string | null =
-    revivalUsed
-      ? '이미 부활을 사용했습니다'
-      : coinBalance < 5
-        ? `코인이 부족합니다 (현재 ${coinBalance}개)`
-        : null
+  if (!canRevive) return null
 
   return (
     <div
@@ -24,35 +17,26 @@ export function RevivalButton({ coinBalance, revivalUsed, isProcessing, onRevive
       onPointerDown={(e) => e.stopPropagation()}  // backdrop onPointerDown={onConfirm} 버블링 차단
     >
       <button
-        onPointerDown={canRevive && !isProcessing ? onRevive : (e) => e.stopPropagation()}
-        disabled={!canRevive || isProcessing}
+        onPointerDown={!isProcessing ? onRevive : (e) => e.stopPropagation()}
+        disabled={isProcessing}
         style={{
           width: '100%',
           padding: '14px 0',
           borderRadius: 8,
-          border: `1px solid ${canRevive ? 'var(--vb-accent)' : 'var(--vb-border)'}`,
+          border: '1px solid var(--vb-accent)',
           backgroundColor: 'transparent',
-          color: canRevive ? 'var(--vb-accent)' : 'var(--vb-text-dim)',
+          color: 'var(--vb-accent)',
           fontFamily: 'var(--vb-font-score)',
           fontSize: 14,
           fontWeight: 900,
           letterSpacing: 2,
-          cursor: canRevive ? 'pointer' : 'default',
+          cursor: 'pointer',
           opacity: isProcessing ? 0.6 : 1,
           transition: 'opacity 0.2s',
         }}
       >
         {isProcessing ? '처리 중...' : '🪙 5코인으로 부활'}
       </button>
-      {disabledReason && (
-        <div style={{
-          fontSize: 11,
-          color: 'var(--vb-text-dim)',
-          fontFamily: 'var(--vb-font-body)',
-        }}>
-          {disabledReason}
-        </div>
-      )}
     </div>
   )
 }


### PR DESCRIPTION
## Summary
- 코인 < 5 또는 이미 부활 사용 시 RevivalButton을 `null` 반환하여 버튼 자체를 숨김
- `disabledReason` 로직, "코인이 부족합니다" 텍스트, disabled 스타일 분기 제거
- 테스트 12건 재작성 (canRevive=false → `queryByRole('button') === null` 검증)

## Test plan
- [x] `tsc --noEmit` PASS
- [x] 테스트 12건 / 전체 373건 PASS
- [ ] 코인 < 5 상태에서 게임오버 → 부활 버튼 미노출 확인
- [ ] 코인 >= 5 & 미사용 → 활성 버튼 노출 확인
- [ ] 부활 사용 후 → 버튼 미노출 확인

Closes #117

🤖 Generated with [Claude Code](https://claude.com/claude-code)