### PR TITLE
fix(game): 부활 후 예제 시퀀스 미표시 수정 (#121)

### DIFF
--- a/docs/bugfix/#117-revival-button-hide-on-no-coins.md
+++ b/docs/bugfix/#117-revival-button-hide-on-no-coins.md
@@ -1,0 +1,174 @@
+---
+depth: simple
+---
+# Bugfix #117 — RevivalButton: 코인 부족 시 불필요 렌더링 제거
+
+## 이슈
+[#117](https://github.com/alruminum/memory-battle/issues/117) — 코인 < 5 일 때 비활성 부활 버튼 + "코인이 부족합니다" 텍스트가 노출됨
+
+## 근본 원인
+`RevivalButton.tsx`에 `canRevive === false` 시 early return null 처리가 누락되어 있다.
+현재는 `canRevive` 값과 무관하게 항상 버튼 DOM을 렌더링하고, `disabled` prop + `disabledReason` 텍스트로 UI를 분기한다.
+
+PRD는 "코인 부족 시 부활 UI 자체를 숨긴다"고 규정하므로 disabled 렌더링 경로가 스펙 위반이다.
+
+## 수정 범위
+
+| 파일 | 변경 유형 | 내용 |
+|---|---|---|
+| `src/components/game/RevivalButton.tsx` | 코드 수정 | `canRevive=false` early return null, `disabledReason` 로직 제거, disabled 스타일 분기 제거 |
+| `src/components/game/RevivalButton.test.tsx` | 테스트 재작성 | 기존 "disabled + 텍스트" 검증 → "null 반환" 검증으로 교체 |
+
+> `GameOverOverlay.tsx` 변경 없음 — RevivalButton이 null 반환 시 래퍼 div(marginTop:16)는 사실상 빈 공간이나, 버그 재현 조건에서 시각적 노출 문제가 없으므로 스코프 외.
+
+---
+
+## 1. `src/components/game/RevivalButton.tsx`
+
+### 변경 전 구조
+
+```
+canRevive 계산
+disabledReason 계산 (revivalUsed / coinBalance < 5 분기)
+return (
+  <div>
+    <button disabled={!canRevive || isProcessing} ...>
+      {isProcessing ? '처리 중...' : '🪙 5코인으로 부활'}
+    </button>
+    {disabledReason && <div>{disabledReason}</div>}  ← 항상 렌더
+  </div>
+)
+```
+
+### 변경 후 구조
+
+```
+canRevive 계산
+if (!canRevive) return null   ← 추가
+
+return (
+  <div onPointerDown stopPropagation>
+    <button onPointerDown={isProcessing ? stopProp : onRevive}
+            disabled={isProcessing}        ← isProcessing만 남김
+            style={{ border: accent, color: accent, ... }}>  ← 단일 스타일 (분기 제거)
+      {isProcessing ? '처리 중...' : '🪙 5코인으로 부활'}
+    </button>
+                                           ← disabledReason div 완전 삭제
+  </div>
+)
+```
+
+### 의사코드 diff
+
+```tsx
+// BEFORE
+const canRevive = !revivalUsed && coinBalance >= 5
+
+const disabledReason: string | null =
+  revivalUsed
+    ? '이미 부활을 사용했습니다'
+    : coinBalance < 5
+      ? `코인이 부족합니다 (현재 ${coinBalance}개)`
+      : null
+
+return (
+  <div ...>
+    <button disabled={!canRevive || isProcessing} ...>
+    {disabledReason && <div>{disabledReason}</div>}
+  </div>
+)
+
+// AFTER
+const canRevive = !revivalUsed && coinBalance >= 5
+if (!canRevive) return null           // ← 추가
+
+// disabledReason 변수 삭제
+
+return (
+  <div ...>
+    <button
+      onPointerDown={!isProcessing ? onRevive : (e) => e.stopPropagation()}
+      disabled={isProcessing}         // ← canRevive 조건 제거 (항상 canRevive=true 보장)
+      style={{
+        border: '1px solid var(--vb-accent)',  // ← 단일 스타일 (분기 없음)
+        color: 'var(--vb-accent)',
+        cursor: 'pointer',
+        opacity: isProcessing ? 0.6 : 1,
+        ...
+      }}
+    >
+      {isProcessing ? '처리 중...' : '🪙 5코인으로 부활'}
+    </button>
+    {/* disabledReason div 삭제 */}
+  </div>
+)
+```
+
+### 결정 근거
+- `canRevive=false`인 경우는 두 가지(`revivalUsed=true`, `coinBalance<5`)이며, 두 경우 모두 부활 버튼을 노출할 필요가 없다.
+- PRD: "코인 부족 시 부활 UI 숨김" — disabled 상태로 표시하는 것과 null 반환은 전혀 다른 UX.
+- early return null 이후 코드에서 `canRevive`는 항상 true이므로, 버튼의 disabled/스타일 분기가 불필요해진다.
+
+---
+
+## 2. `src/components/game/RevivalButton.test.tsx`
+
+### 기존 테스트 중 변경 필요한 케이스
+
+| 기존 테스트 설명 | 변경 방향 |
+|---|---|
+| `coinBalance=4 → disabled + "코인이 부족합니다"` | `queryByRole('button') === null` 로 교체 |
+| `coinBalance=0 → disabled + "코인이 부족합니다"` | `queryByRole('button') === null` 로 교체 |
+| `revivalUsed=true → disabled + "이미 부활을 사용했습니다"` | `queryByRole('button') === null` 로 교체 |
+| `revivalUsed=true && coinBalance>=5 → "이미 부활을 사용했습니다"` | `queryByRole('button') === null` 로 교체 |
+| `disabled(revivalUsed=true) pointerDown → onRevive 미호출` | 버튼이 null이므로 테스트 방식 조정 |
+| `disabled(coinBalance<5) pointerDown → onRevive 미호출` | 버튼이 null이므로 테스트 방식 조정 |
+
+### 추가/유지 테스트
+
+- `canRevive=true이면 disabledReason 텍스트 없음` → 유지 (null 반환 없음 경로)
+- `canRevive=false → renders nothing (null)` 케이스를 명시적 테스트로 추가
+- `isProcessing=true → disabled + "처리 중..."` → 유지 (canRevive=true 전제)
+- 버블링 차단(wrapper stopPropagation) 테스트 → 유지 (canRevive=true 전제)
+
+### 신규 테스트 의사코드
+
+```ts
+// canRevive=false 케이스 통합
+describe('RevivalButton — canRevive=false → null', () => {
+  it('coinBalance=4 → renders nothing', () => {
+    const { queryByRole } = render(<RevivalButton {...defaultProps} coinBalance={4} />)
+    expect(queryByRole('button')).toBeNull()
+  })
+
+  it('coinBalance=0 → renders nothing', () => {
+    const { queryByRole } = render(<RevivalButton {...defaultProps} coinBalance={0} />)
+    expect(queryByRole('button')).toBeNull()
+  })
+
+  it('revivalUsed=true → renders nothing', () => {
+    const { queryByRole } = render(<RevivalButton {...defaultProps} revivalUsed={true} />)
+    expect(queryByRole('button')).toBeNull()
+  })
+
+  it('revivalUsed=true && coinBalance>=5 → renders nothing', () => {
+    const { queryByRole } = render(<RevivalButton {...defaultProps} revivalUsed={true} coinBalance={10} />)
+    expect(queryByRole('button')).toBeNull()
+  })
+})
+```
+
+---
+
+## 주의사항
+
+- `GameOverOverlay` 의 래퍼 `<div style={{ marginTop: 16 }}>` 는 RevivalButton=null 시에도 DOM에 남는다. 시각적 공간 영향은 무시 가능(height: 0 + 안의 내용 없음)하므로 이번 스코프에서 제외. 후속 개선 시 `canRevive` 조건으로 래퍼 조건부 렌더링 가능.
+- `disabled` prop은 `isProcessing`만 남기므로, `canRevive && !isProcessing` 형태의 조건식은 `!isProcessing`으로 단순화.
+
+## 체크리스트
+
+- [ ] `canRevive` false → early return null
+- [ ] `disabledReason` 변수 및 렌더링 완전 제거
+- [ ] disabled 스타일 분기(border/color/cursor) → 단일 accent 스타일로 교체
+- [ ] `disabled={!canRevive || isProcessing}` → `disabled={isProcessing}` 로 단순화
+- [ ] 테스트: canRevive=false 케이스 6건 → null 반환 검증으로 재작성

--- a/docs/bugfix/#119-eslint-cleanup.md
+++ b/docs/bugfix/#119-eslint-cleanup.md
@@ -1,0 +1,444 @@
+---
+depth: simple
+---
+# #119 버그픽스 — ESLint 전체 에러/경고 28건 일괄 수정
+
+> 원래 이슈: [#119](https://github.com/alruminum/memory-battle/issues/119)
+
+---
+
+## 개요
+
+`npx eslint . --max-warnings 0` 실행 시 23 errors + 5 warnings(총 28건) 발생.
+하네스 autocheck 게이트 실패 원인. 0 errors, 0 warnings 달성이 목표.
+
+---
+
+## 결정 근거
+
+### D1 — coverage/ 디렉토리: `.eslintignore` 대신 `globalIgnores` 활용
+
+커버리지 출력물(block-navigation.js 등)은 자동 생성 파일로 ESLint 대상이 아니다.
+flat config에서는 `.eslintignore`가 deprecated — `eslint.config.js`의 `globalIgnores(['dist', 'coverage'])`로 통합 관리.
+
+| 옵션 | 설명 | 채택 |
+|---|---|---|
+| A: `.eslintignore` 신규 생성 | deprecated in flat config | ❌ |
+| **B: `globalIgnores` 수정 (채택)** | flat config 표준, 1줄 변경 | ✅ |
+
+### D2 — `_`-접두사 미사용 인자: 규칙 오버라이드로 일괄 처리
+
+`_table`, `_col`, `_val`, `_duration`, `_multiplier` 등 6건이 `@typescript-eslint/no-unused-vars`에 걸린다.
+모두 **의도적으로 타입 시그니처 매칭용으로 선언한 파라미터**이며 `_` 접두사가 이미 명시돼 있다.
+`tseslint.configs.recommended`의 기본값은 `argsIgnorePattern`을 설정하지 않는다.
+개별 suppresssion 대신 eslint.config.js에서 `argsIgnorePattern: '^_'`으로 전체 해결.
+
+### D3 — `react-refresh/only-export-components`: FloatingScore 유틸 분리
+
+`FloatingScore.tsx`가 컴포넌트 외 함수 3개(`getLabelColor`, `getLabelSize`, `getLabelGlow`)를 export해 rule 위반.
+이미 2개 테스트 파일(`FloatingScore.test.ts`, `FloatingScore.fix.test.tsx`)이 이 함수들을 직접 import한다.
+
+| 옵션 | 설명 | 채택 |
+|---|---|---|
+| A: re-export 유지 | re-export 해도 rule은 여전히 위반 | ❌ |
+| **B: `floatingScoreUtils.ts` 신규 분리 (채택)** | rule 의도에 맞고, 테스트 import 경로만 업데이트 | ✅ |
+| C: rule 억제 (`allowConstantExport`) | fast refresh 목적의 rule을 비활성화하는 건 근본 원인 미해결 | ❌ |
+
+**영향 범위**: `FloatingScore.tsx`, `FloatingScore.test.ts`, `FloatingScore.fix.test.tsx` (import 경로 수정).
+`GamePage.tsx`는 `FloatingScore` 컴포넌트·`FloatingItem` 타입만 사용 — 변경 불필요.
+
+### D4 — `as any` in test mocks: `as unknown as Type` 패턴
+
+`mockReturnValue({ ... } as any)` 패턴에서 `any` 제거.
+`as unknown as ReturnType<typeof hook>` 이중 캐스팅이 표준 대안 — `unknown`은 no-explicit-any에 해당하지 않음.
+MainPage 테스트의 `makeStoreMock`은 로컬 인터페이스 정의로 해결.
+
+### D5 — `react-hooks/set-state-in-effect` in ComboIndicator: 인라인 파생 상태 패턴
+
+ComboIndicator의 `useEffect(() => { setIsShaking(isBreaking) }, [isBreaking])` 패턴은 prop → state 동기화로 useEffect 없이 render 중 처리 가능.
+React 문서 "Adjusting some state when a prop changes" 패턴(prevRef + 렌더 중 조건부 setState) 사용.
+
+```
+isBreaking false→true: prevRef=false, current=true → setIsShaking(true) (렌더 중 즉시)
+애니메이션 종료: handleAnimationEnd → setIsShaking(false)
+isBreaking true→false (게임 재시작): prevRef=true, current=false → setIsShaking(false)
+```
+
+이 패턴은 lint rule을 통과하며 기존 동작을 보존한다.
+
+### D6 — `react-hooks/set-state-in-effect` in ComboTimer: eslint-disable 억제
+
+ComboTimer의 두 지점(`setCollapsePhase('none')` line 68, `setElapsedMs(0)` line 82)은 interval 관리·VisibilityAPI 핸들러와 얽혀 있어 인라인 파생 상태로 분리 시 타이밍 부작용 위험이 높다.
+이 effect들은 의도적인 prop→state 동기화이며, `eslint-disable-next-line`으로 억제 + 사유 주석 기재.
+
+### D7 — `react-hooks/purity` in MultiplierBurst: eslint-disable 억제
+
+`useMemo` 안의 `Math.random()` 호출. 파티클 좌표는 매 isVisible 변경마다 다른 값이어야 하는 **의도적 랜덤성** — `useEffect`+`useState`로 이전하면 `set-state-in-effect` 위반이 새로 발생하고 렌더 타이밍이 복잡해진다.
+`useMemo` 패턴이 기능적으로 맞으므로 `eslint-disable-next-line`으로 억제.
+
+### D8 — `debug.ts`: 오정렬 disable 주석 + `any[]` → `unknown[]`
+
+기존 `eslint-disable-next-line`이 ternary 2번째 줄(함수 선언 줄)이 아닌 1번째 줄(const 선언)에 위치해 disable이 적용되지 않음 → unused directive warning + 3번째 줄 error 이중 발생.
+근본 수정: `any[]` → `unknown[]` 타입 교체 (console.log/warn 시그니처는 `any[]`를 수용하므로 컴파일 가능).
+
+---
+
+## 수정 파일 목록
+
+| # | 파일 | 변경 유형 | 수정 건수 |
+|---|---|---|---|
+| 1 | `eslint.config.js` | 수정 | coverage ignore + argsIgnorePattern |
+| 2 | `src/components/game/floatingScoreUtils.ts` | **신규** | 유틸 함수 3개 추출 |
+| 3 | `src/components/game/FloatingScore.tsx` | 수정 | 유틸 함수 제거 → import 전환 |
+| 4 | `src/__tests__/FloatingScore.test.ts` | 수정 | import 경로 |
+| 5 | `src/__tests__/FloatingScore.fix.test.tsx` | 수정 | import 경로 |
+| 6 | `src/__tests__/MainPage.coin-ui-polish.test.tsx` | 수정 | `any` → `MockStoreState` |
+| 7 | `src/__tests__/ResultPage.coin-ui-polish.test.tsx` | 수정 | `as any` → `as unknown as Type` |
+| 8 | `src/components/game/ComboIndicator.tsx` | 수정 | set-state-in-effect 제거 |
+| 9 | `src/components/game/ComboTimer.tsx` | 수정 | eslint-disable 2건 |
+| 10 | `src/components/game/MultiplierBurst.tsx` | 수정 | eslint-disable 2건 |
+| 11 | `src/lib/debug.ts` | 수정 | `any[]` → `unknown[]`, 오정렬 주석 제거 |
+
+---
+
+## 1. `eslint.config.js`
+
+### 변경 사항
+
+```js
+// Before:
+globalIgnores(['dist']),
+
+// After:
+globalIgnores(['dist', 'coverage']),
+```
+
+그리고 `files: ['**/*.{ts,tsx}']` 블록 안에 `rules` 섹션 추가:
+
+```js
+{
+  files: ['**/*.{ts,tsx}'],
+  extends: [
+    js.configs.recommended,
+    tseslint.configs.recommended,
+    reactHooks.configs.flat.recommended,
+    reactRefresh.configs.vite,
+  ],
+  languageOptions: {
+    ecmaVersion: 2020,
+    globals: globals.browser,
+  },
+  rules: {
+    // _접두사 파라미터/변수는 의도적 미사용으로 허용 (mock 시그니처 매칭 등)
+    '@typescript-eslint/no-unused-vars': [
+      'error',
+      { argsIgnorePattern: '^_', varsIgnorePattern: '^_', caughtErrorsIgnorePattern: '^_' },
+    ],
+  },
+},
+```
+
+**해결 건수**: coverage 3 warnings + `_table`/`_col`×2/`_val`/`_duration`×2/`_multiplier` = 총 10건
+
+---
+
+## 2. `src/components/game/floatingScoreUtils.ts` (신규)
+
+```typescript
+import type { ButtonColor } from '../../types'
+
+// IMPORTANT: hex 값은 src/index.css :root의 CSS 변수와 일치해야 한다.
+// 색상 변경 시 두 곳 모두 수정 필요:
+//   --vb-orange-base, --vb-blue-base, --vb-green-base, --vb-yellow-base
+// CSS 변수 문자열 연결(예: 'var(--vb-orange-base)88')은 유효하지 않은 CSS가 되어
+// text-shadow 전체가 파싱 실패함 → hex 직접 사용이 유일한 안전한 방법.
+export const BUTTON_COLORS: Record<ButtonColor, string> = {
+  orange: '#FF6200',
+  blue:   '#0A7AFF',
+  green:  '#18B84A',
+  yellow: '#F5C000',
+}
+
+export function getLabelColor(color: ButtonColor, _multiplier?: number): string {
+  return BUTTON_COLORS[color]
+}
+
+const SIZE_TABLE: Record<number, number> = { 1: 24, 2: 30, 3: 36, 4: 40 }
+
+export function getLabelSize(multiplier: number): number {
+  if (multiplier >= 5) return 44
+  return SIZE_TABLE[multiplier] ?? 24
+}
+
+export function getLabelGlow(color: ButtonColor, multiplier: number): string {
+  if (multiplier < 2) return 'none'
+  const base = BUTTON_COLORS[color]
+  const strength = 8 + multiplier * 4
+  const spread = 20 + multiplier * 6
+  return `0 0 ${strength}px ${base}, 0 0 ${spread}px ${base}88`
+}
+```
+
+> 주의: `_multiplier`는 `argsIgnorePattern: '^_'` 설정으로 lint 통과. 기존 테스트 호출 시그니처(`getLabelColor(color, multiplier)`) 유지를 위해 제거하지 않음.
+
+---
+
+## 3. `src/components/game/FloatingScore.tsx`
+
+### 변경 사항
+
+1. 기존 `BUTTON_COLORS`, `getLabelColor`, `SIZE_TABLE`, `getLabelSize`, `getLabelGlow` 선언 **삭제**
+2. `import` 구문 추가:
+   ```tsx
+   import { getLabelColor, getLabelSize, getLabelGlow } from './floatingScoreUtils'
+   ```
+3. 기존 `import React from 'react'`와 `import type { ButtonColor } from '../../types'` 유지 (FloatingItem 인터페이스는 이 파일에 남겨 GamePage.tsx import 호환 유지)
+
+### 핵심 불변 조건
+
+- `FloatingItem` 인터페이스와 `FloatingScore` 컴포넌트는 이 파일에 **그대로 유지**
+- `GamePage.tsx`의 `import { FloatingScore, type FloatingItem } from '../components/game/FloatingScore'` 변경 불필요
+
+---
+
+## 4. `src/__tests__/FloatingScore.test.ts`
+
+### import 수정
+
+```ts
+// Before:
+import { getLabelColor, getLabelSize, getLabelGlow } from '../components/game/FloatingScore'
+
+// After:
+import { getLabelColor, getLabelSize, getLabelGlow } from '../components/game/floatingScoreUtils'
+```
+
+---
+
+## 5. `src/__tests__/FloatingScore.fix.test.tsx`
+
+### import 분리
+
+```tsx
+// Before:
+import { getLabelColor, getLabelGlow, FloatingScore } from '../components/game/FloatingScore'
+import type { FloatingItem } from '../components/game/FloatingScore'
+
+// After:
+import { FloatingScore } from '../components/game/FloatingScore'
+import type { FloatingItem } from '../components/game/FloatingScore'
+import { getLabelColor, getLabelGlow } from '../components/game/floatingScoreUtils'
+```
+
+---
+
+## 6. `src/__tests__/MainPage.coin-ui-polish.test.tsx`
+
+### 변경 사항: `makeStoreMock` 타입 명시
+
+```tsx
+// Before (line 28-39):
+function makeStoreMock(coinBalance: number) {
+  return (selector?: (s: any) => any) => {
+    const state = {
+      userId: '',
+      setUserId: vi.fn(),
+      score: 0,
+      stage: 1,
+      coinBalance,
+    }
+    return typeof selector === 'function' ? selector(state) : state
+  }
+}
+
+// After:
+interface MockStoreState {
+  userId: string
+  setUserId: ReturnType<typeof vi.fn>
+  score: number
+  stage: number
+  coinBalance: number
+}
+
+function makeStoreMock(coinBalance: number) {
+  return (selector?: (s: MockStoreState) => unknown) => {
+    const state: MockStoreState = {
+      userId: '',
+      setUserId: vi.fn(),
+      score: 0,
+      stage: 1,
+      coinBalance,
+    }
+    return typeof selector === 'function' ? selector(state) : state
+  }
+}
+```
+
+> `mockGetBalance` (line 25)는 사용되므로 변경 없음.
+
+---
+
+## 7. `src/__tests__/ResultPage.coin-ui-polish.test.tsx`
+
+### 변경 사항: `as any` → `as unknown as ReturnType<...>`
+
+총 4건. 각 mock의 실제 hook import가 이미 파일 상단에 있으므로 `ReturnType<typeof hook>` 사용 가능.
+
+```tsx
+// line 51 (useGameStore mock):
+} as unknown as ReturnType<typeof useGameStore>)
+
+// line 58 (useRanking mock):
+} as unknown as ReturnType<typeof useRanking>)
+
+// line 63 (useRewardAd mock):
+} as unknown as ReturnType<typeof useRewardAd>)
+
+// line 68 (useCoin mock):
+} as unknown as ReturnType<typeof useCoin>)
+```
+
+---
+
+## 8. `src/components/game/ComboIndicator.tsx`
+
+### 변경 사항: useEffect 제거 → 인라인 파생 상태
+
+```tsx
+// Before imports:
+import { useState, useEffect, useCallback } from 'react'
+
+// After imports:
+import { useState, useRef, useCallback } from 'react'
+```
+
+컴포넌트 본문에서 기존 `useEffect` 블록(line 14-20) 제거하고 아래로 교체:
+
+```tsx
+export function ComboIndicator({ comboStreak, isBreaking = false }: ComboIndicatorProps) {
+  const [isShaking, setIsShaking] = useState(false)
+
+  // isBreaking prop→state 동기화: React 파생 상태 패턴 (useEffect 없이 렌더 중 처리)
+  // ref.current ≠ isBreaking 일 때만 setState → 렌더 루프 방지
+  const prevIsBreaking = useRef(isBreaking)
+  if (prevIsBreaking.current !== isBreaking) {
+    prevIsBreaking.current = isBreaking
+    setIsShaking(isBreaking)
+  }
+
+  const handleAnimationEnd = useCallback((e: React.AnimationEvent<HTMLDivElement>) => {
+    if (e.animationName === 'comboBreakShake') {
+      setIsShaking(false)  // 애니메이션 완료 후 클래스 제거
+    }
+  }, [])
+
+  // ... 이하 JSX 변경 없음
+```
+
+### 동작 검증
+
+| 시나리오 | 기대 결과 |
+|---|---|
+| isBreaking false→true | prevRef=false≠true → setIsShaking(true) → 쉐이크 시작 |
+| 애니메이션 완료 (isBreaking=true 유지) | handleAnimationEnd → setIsShaking(false), prevRef=true=true → no-op |
+| isBreaking true→false (게임 재시작) | prevRef=true≠false → setIsShaking(false) → 즉시 정지 |
+
+---
+
+## 9. `src/components/game/ComboTimer.tsx`
+
+### 변경 사항: eslint-disable-next-line 2건 추가
+
+**line 68 (`setCollapsePhase('none')` 앞):**
+```tsx
+  if (!isBreaking) {
+    // isBreaking prop→state 동기화: interval+VisibilityAPI 로직과 얽혀 있어
+    // 인라인 파생 상태 분리 시 타이밍 부작용 우려 — 의도적 suppression
+    // eslint-disable-next-line react-hooks/set-state-in-effect
+    setCollapsePhase('none')
+    return
+  }
+```
+
+**line 82 (`setElapsedMs(0)` 앞):**
+```tsx
+    // interval 정지와 elapsedMs 초기화를 동일 effect에서 처리 — 의도적 suppression
+    // eslint-disable-next-line react-hooks/set-state-in-effect
+    setElapsedMs(0)
+    return
+```
+
+---
+
+## 10. `src/components/game/MultiplierBurst.tsx`
+
+### 변경 사항: eslint-disable-next-line 2건 추가
+
+`useMemo` 내부 line 33, 34:
+
+```tsx
+  return Array.from({ length: PARTICLE_COUNT }, (_, i) => {
+    const angle = (360 / PARTICLE_COUNT) * i
+    const rad = (angle * Math.PI) / 180
+    // 파티클 좌표는 isVisible 변경마다 의도적으로 다른 값이어야 함 (시각적 랜덤성)
+    // useEffect로 이전 시 set-state-in-effect 위반이 새로 발생 — useMemo 유지
+    // eslint-disable-next-line react-hooks/purity
+    const dist = 80 + Math.random() * 40
+    // eslint-disable-next-line react-hooks/purity
+    const size = 8 + Math.random() * 6
+    return {
+      px: Math.cos(rad) * dist,
+      py: Math.sin(rad) * dist,
+      size,
+      delay: i * 25,
+    }
+  })
+```
+
+---
+
+## 11. `src/lib/debug.ts`
+
+### 변경 사항: `any[]` → `unknown[]`, 오정렬 주석 제거
+
+```typescript
+// Before:
+// eslint-disable-next-line @typescript-eslint/no-explicit-any
+export const dbg = import.meta.env.DEV
+  ? (...args: any[]) => console.log(...args)
+  : () => {}
+
+// eslint-disable-next-line @typescript-eslint/no-explicit-any
+export const dbgWarn = import.meta.env.DEV
+  ? (...args: any[]) => console.warn(...args)
+  : () => {}
+
+// After:
+export const dbg = import.meta.env.DEV
+  ? (...args: unknown[]) => console.log(...args)
+  : () => {}
+
+export const dbgWarn = import.meta.env.DEV
+  ? (...args: unknown[]) => console.warn(...args)
+  : () => {}
+```
+
+> 근거: `console.log`/`warn` 시그니처는 `(...data: any[])` — `unknown[]`의 스프레드는 TypeScript에서 허용됨(unknown은 any로 할당 가능). 기존 `eslint-disable-next-line`은 3번째 줄(ternary 분기)이 아닌 1번째 줄(const 선언)을 억제하고 있어 실제 효과 없음 + "unused directive" warning 발생 → 주석 삭제 + 타입 교체로 근본 해결.
+
+---
+
+## 최종 기대 결과
+
+```
+$ npx eslint . --max-warnings 0
+✓ 0 errors, 0 warnings
+```
+
+---
+
+## 주의사항
+
+- `FloatingScore.tsx`에서 `BUTTON_COLORS`를 제거할 때 파일 상단의 **주석(CSS 변수 경고)**도 `floatingScoreUtils.ts`로 함께 이전한다
+- `FloatingScore.tsx` 내 `FloatingScore` 컴포넌트가 `floatingScoreUtils`의 함수를 정상 호출하는지 로컬 빌드(`npm run build`)로 확인
+- `ComboIndicator` 변경 후 `isBreaking` prop이 `GameOverOverlay` 등 호출부에서 올바르게 전달되는지 회귀 테스트 포함
+- 이 수정은 **동작 변경 없음** — ESLint 0/0 달성 목적만

--- a/docs/bugfix/#121-revival-sequence-showing-fix.md
+++ b/docs/bugfix/#121-revival-sequence-showing-fix.md
@@ -1,0 +1,133 @@
+---
+depth: simple
+---
+# #121 버그픽스 — 코인 부활 후 시퀀스 예제(깜빡임) 미표시
+
+> 원래 이슈: [#121](https://github.com/alruminum/memory-battle/issues/121)
+
+---
+
+## 개요
+
+코인 5개로 부활 시, 현재 스테이지 시퀀스 깜빡임을 다시 보여주지 않고 즉시 INPUT 대기 상태로 전환되는 버그.
+
+**근본 원인**:
+`revive()`가 `sequence: []`로 초기화한 뒤 `status: 'SHOWING'`으로 전환한다.  
+`useGameEngine.ts`의 SHOWING 브랜치는 아래 루프로 점등을 처리한다:
+
+```ts
+// useGameEngine.ts L50-52
+const next = () => {
+  if (i >= sequence.length) {   // 0 >= 0 → 즉시 true
+    useGameStore.setState({ status: 'INPUT', ... })  // 바로 INPUT 전환
+  }
+  ...
+}
+next()   // sequence=[] 상태에서 호출 → 점등 루프 없이 INPUT으로 점프
+```
+
+`sequence` 길이가 0이면 루프가 즉시 완료(점등 없음)되어 INPUT으로 직행한다.  
+원래 코드 주석 `// useGameEngine이 감지해 stage 길이 새 시퀀스 생성`은 실제로 구현되지 않았다.
+
+---
+
+## 결정 근거
+
+### D1 — 수정 위치: `gameStore.ts` `revive()` (채택)
+
+| 옵션 | 설명 | 채택 여부 |
+|---|---|---|
+| **A: `revive()`에서 `sequence: []` 제거 (채택)** | 기존 시퀀스 유지. status만 'SHOWING'으로 전환. SHOWING 효과가 정상 시퀀스로 동작 | ✅ 채택 |
+| B: `useGameEngine.ts` SHOWING 브랜치 수정 | `sequence.length === 0` 감지 시 stage 길이로 새 시퀀스 생성 후 점등 | ❌ 미채택 — 코드량 증가, `randomButton()` 호출이 useEffect 내에 추가됨. gameStore에 이미 올바른 시퀀스가 있는데 굳이 새 시퀀스 생성할 이유 없음 |
+
+**A 채택 근거**:
+- `gameOver()` 호출 시 `state.sequence`는 건드리지 않는다. 실패 스테이지의 시퀀스가 그대로 남아 있다.
+- `revive()` 후 status: 'SHOWING' 변경 → useEffect deps `[status, sequence, timer]` 트리거 → showingRef.current는 RESULT 진입 시 이미 false로 리셋됨 → 점등 루프 정상 실행.
+- 단일 파일 한 줄(+주석) 삭제로 완결. `useGameEngine.ts` 변경 불필요.
+
+### D2 — 동일 시퀀스 vs 새 시퀀스 재생성
+
+부활 후 플레이어가 보는 시퀀스는 직전 실패 시퀀스와 동일하다.  
+이슈 요구사항 "현재 스테이지의 시퀀스를 처음부터 다시 깜빡임으로 보여준 뒤" = **같은 시퀀스 재표시**가 가장 자연스럽다.  
+새 시퀀스를 생성하면 플레이어가 처음 보는 시퀀스로 바뀌어 부활의 의미(같은 스테이지 재시도)가 퇴색된다.
+
+---
+
+## 수정 파일
+
+- `src/store/gameStore.ts` (수정)
+
+---
+
+## gameStore.ts
+
+### 수정 대상: `revive()` L191-198
+
+**현행**
+```ts
+return {
+  status: 'SHOWING',
+  sequence: [],       // useGameEngine이 감지해 stage 길이 새 시퀀스 생성
+  currentIndex: 0,
+  revivalUsed: true,
+  // score, stage, comboStreak, fullComboCount, maxComboStreak 유지
+}
+```
+
+**변경 후**
+```ts
+return {
+  status: 'SHOWING',
+  // sequence 유지 — 실패한 스테이지의 시퀀스를 SHOWING에서 다시 점등
+  currentIndex: 0,
+  revivalUsed: true,
+  // score, stage, comboStreak, fullComboCount, maxComboStreak 유지
+}
+```
+
+> `sequence: []` 한 줄 + 주석 제거. 나머지 필드 변경 없음.
+
+---
+
+## 플로우 검증 (변경 후)
+
+```
+gameOver() 호출 시
+  state.sequence = [orange, blue, green, ...]  ← 변경 없음
+  state.status = 'RESULT'
+  state.stage = sequence.length
+
+revive() 호출 시
+  state.status = 'SHOWING'            ← 변경
+  state.currentIndex = 0             ← 변경
+  state.revivalUsed = true           ← 변경
+  state.sequence = [orange, blue, green, ...]  ← 유지 (삭제 전 기존 배열 그대로)
+
+useGameEngine SHOWING 효과 (status 변경으로 트리거)
+  showingRef.current = false (RESULT 진입 시 리셋됨)
+  → showingRef.current = true 세팅
+  → sequence.length = N (> 0)
+  → i=0부터 N-1까지 점등 루프 정상 실행
+  → 완료 후 INPUT 전환
+```
+
+---
+
+## 주의사항
+
+- **`useGameEngine.ts` 변경 없음** — SHOWING 브랜치 로직 그대로 유지
+- **`revivalUsed` 가드 유지** — 이미 부활 사용 시 `revive()` 무시 동작 불변
+- **기존 정상 게임플로우 무영향** — `startGame()` / 스테이지 클리어 후 SHOWING 진입 경로와 무관. 두 경로 모두 non-empty sequence로 SHOWING에 진입하므로 동작 동일
+- **`currentIndex: 0` 필수** — `gameOver()` 호출 시 currentIndex가 중간값일 수 있음. 리셋하지 않으면 INPUT 페이즈에서 첫 버튼 기대값 오류
+
+---
+
+## 수동 검증
+
+| ID | 시나리오 | 기대 동작 |
+|---|---|---|
+| MV-1 | 게임 시작 → 스테이지 진행 → 오답 → 부활 버튼 클릭 | 현재 스테이지 시퀀스 깜빡임 표시 후 INPUT 전환 |
+| MV-2 | MV-1 후 정상 입력 완료 | 스테이지 클리어 → 다음 스테이지 SHOWING 정상 진행 |
+| MV-3 | MV-1 후 오답 입력 | 게임오버 (revivalUsed=true이므로 2번째 부활 불가) |
+| MV-4 | 부활 없이 일반 게임오버 → 다시 시작 | 카운트다운 → SHOWING 정상 (회귀 없음) |
+| MV-5 | 스테이지 1에서 부활 | 1-버튼 시퀀스 깜빡임 표시 후 INPUT 전환 |

--- a/src/components/game/floatingScoreUtils.ts
+++ b/src/components/game/floatingScoreUtils.ts
@@ -1,0 +1,32 @@
+import type { ButtonColor } from '../../types'
+
+// IMPORTANT: hex 값은 src/index.css :root의 CSS 변수와 일치해야 한다.
+// 색상 변경 시 두 곳 모두 수정 필요:
+//   --vb-orange-base, --vb-blue-base, --vb-green-base, --vb-yellow-base
+// CSS 변수 문자열 연결(예: 'var(--vb-orange-base)88')은 유효하지 않은 CSS가 되어
+// text-shadow 전체가 파싱 실패함 → hex 직접 사용이 유일한 안전한 방법.
+const BUTTON_COLORS: Record<ButtonColor, string> = {
+  orange: '#FF6200',
+  blue:   '#0A7AFF',
+  green:  '#18B84A',
+  yellow: '#F5C000',
+}
+
+export function getLabelColor(color: ButtonColor, _multiplier?: number): string {
+  return BUTTON_COLORS[color]
+}
+
+const SIZE_TABLE: Record<number, number> = { 1: 24, 2: 30, 3: 36, 4: 40 }
+
+export function getLabelSize(multiplier: number): number {
+  if (multiplier >= 5) return 44
+  return SIZE_TABLE[multiplier] ?? 24
+}
+
+export function getLabelGlow(color: ButtonColor, multiplier: number): string {
+  if (multiplier < 2) return 'none'
+  const base = BUTTON_COLORS[color]
+  const strength = 8 + multiplier * 4
+  const spread = 20 + multiplier * 6
+  return `0 0 ${strength}px ${base}, 0 0 ${spread}px ${base}88`
+}

--- a/src/store/gameStore.coin.test.ts
+++ b/src/store/gameStore.coin.test.ts
@@ -84,7 +84,7 @@ describe('revive()', () => {
 
     const state = useGameStore.getState()
     expect(state.status).toBe('SHOWING')
-    expect(state.sequence).toEqual([])
+    expect(state.sequence).toEqual(['orange', 'blue', 'green'])
     expect(state.revivalUsed).toBe(true)
   })
 

--- a/src/store/gameStore.ts
+++ b/src/store/gameStore.ts
@@ -39,7 +39,7 @@ interface GameStore {
 
   // [v0.4] 코인 액션
   setCoinBalance: (balance: number) => void  // useCoin에서 잔액 동기화
-  revive: () => void   // RESULT→SHOWING 전환 (코인 차감은 호출자 책임, 시퀀스 초기화)
+  revive: () => void   // RESULT→SHOWING 전환 (코인 차감은 호출자 책임, sequence 유지 — 실패 스테이지 시퀀스 재점등)
 }
 
 export const useGameStore = create<GameStore>((set, get) => ({
@@ -182,7 +182,6 @@ export const useGameStore = create<GameStore>((set, get) => ({
 
   // RESULT → SHOWING 전환
   // ⚠️ 코인 차감(addCoins(-5,'revival'))은 호출 전 이미 완료되어야 한다
-  // ⚠️ sequence=[] → useGameEngine useEffect가 현재 stage 길이의 새 시퀀스를 생성
   revive: () =>
     set((state) => {
       // 가드: RESULT 상태가 아니거나 이미 부활 사용 시 무시
@@ -190,7 +189,7 @@ export const useGameStore = create<GameStore>((set, get) => ({
       if (state.revivalUsed) return {}
       return {
         status: 'SHOWING',
-        sequence: [],       // useGameEngine이 감지해 stage 길이 새 시퀀스 생성
+        // sequence 유지 — 실패한 스테이지의 시퀀스를 SHOWING에서 다시 점등
         currentIndex: 0,
         revivalUsed: true,
         // score, stage, comboStreak, fullComboCount, maxComboStreak 유지


### PR DESCRIPTION
## Summary
- `revive()`에서 `sequence: []` 초기화 제거 → 실패 시퀀스 유지
- SHOWING 루프가 빈 배열로 즉시 종료되던 문제 해결
- 관련 테스트 기대값 업데이트

## Test plan
- [x] `tsc --noEmit` PASS
- [x] 테스트 373건 전체 PASS
- [ ] 코인 부활 후 예제 시퀀스 점등 확인
- [ ] 정상 게임플로우 영향 없음 확인

Closes #121

🤖 Generated with [Claude Code](https://claude.com/claude-code)