### PR TITLE
fix(ci): Supabase 환경변수 추가 — CI 테스트 실패 수정

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -21,3 +21,6 @@ jobs:
       - run: npm ci
 
       - run: npm run test
+        env:
+          VITE_SUPABASE_URL: http://localhost:54321
+          VITE_SUPABASE_ANON_KEY: ci-dummy-key


### PR DESCRIPTION
## Summary
- GitHub Actions에 `VITE_SUPABASE_URL`/`VITE_SUPABASE_ANON_KEY` 더미 값 추가
- CI에서 supabase.ts 모듈 로드 시 `supabaseUrl is required` 에러로 전체 테스트 실패하던 문제 수정

🤖 Generated with [Claude Code](https://claude.com/claude-code)