### PR TITLE
docs(result): #129 ResultPage 리디자인 문서 현행화

### DIFF
--- a/docs/bugfix/#129-result-redesign.md
+++ b/docs/bugfix/#129-result-redesign.md
@@ -1,0 +1,354 @@
+---
+depth: std
+design: required
+---
+
+# impl: ResultPage 레이아웃 리디자인 (Hero/Stats/CTA 3계층)
+
+## 참조
+- Issue: #129
+- Pencil 확정 노드: `uAYzL` (`design/memoryBattle.pen`)
+- UX Flow: `docs/ux-flow.md` § S04 ResultPage
+- 현재 구현: `src/pages/ResultPage.tsx`
+
+## Design Ref
+- Pencil frame ID: `uAYzL` (ResultPage, 390×837, fill `#0e0e10`, padding [0,20], layout vertical)
+- 핵심 노드
+  | 노드 ID | 역할 |
+  |---|---|
+  | `wqPtP` | rScoreCard — Hero 카드 (surface, cornerRadius 12, padding 24) |
+  | `fJbi7` | stageRow — Stage + 코인 수량 행 (space-between) |
+  | `PjMOx` | rBestBadge — pill 배지 (cornerRadius 999, stroke vb-accent) |
+  | `NY75d` | rComboCard — Stats 통합 카드 (surface, cornerRadius 12, padding 16, gap 12) |
+  | `kQTuo` | statsDivider — 1px 구분선 (#2a2a2e) |
+  | `J0Jlt` | rRankSection — Daily/Monthly/Season 랭킹 3행 |
+  | `UxXnX` | rBtnArea — CTA 섹션 (gap 10, padding [8,0,32,0]) |
+  | `pOzFR` | rPlayBtn — PLAY AGAIN (height 54px, fill #D4A843) |
+- 디자인 토큰: `--vb-accent` (#D4A843), `--vb-surface` (#18181b), `--vb-border` (#2a2a2e), `--vb-danger` (#ff3b3b), `--vb-text-dim` (#505055)
+- 컴포넌트: CoinIcon (신규 C10), NewRecordBadge (pill 재설계)
+
+---
+
+## 생성/수정 파일 목록
+
+| 파일 | 작업 | 사유 |
+|---|---|---|
+| `src/components/result/CoinIcon.tsx` | **신규 생성** | 🪙 이모지 전면 대체 컴포넌트 (UX Flow C10 스펙) |
+| `src/components/result/NewRecordBadge.tsx` | **수정** | 박스형 → pill 배지 재설계 (Pencil `PjMOx` 스펙) |
+| `src/components/result/CoinRewardBadge.tsx` | **수정** | 🪙 → CoinIcon 교체 |
+| `src/components/result/PointExchangeButton.tsx` | **수정** | 🪙 → CoinIcon 교체 |
+| `src/pages/ResultPage.tsx` | **수정** | 전체 레이아웃 Hero/Stats/CTA 3계층 재구성 |
+
+---
+
+## 1. CoinIcon 컴포넌트 (신규)
+
+### 역할
+ResultPage 전역 `🪙` 이모지를 대체하는 커스텀 SVG 코인 아이콘.
+UX Flow C10 스펙: size variant 최소 2종(16/20px), 이모지 금지.
+
+### 설계 결정
+- **SVG 선택 이유**: 이모지는 플랫폼(iOS/Android/WebView)마다 렌더링 형태 다름, 크기·색상 제어 불가.
+  SVG는 크기·색상 완전 제어, 다크 배경 골든 엑센트 일관성 보장.
+- **radialGradient**: 입체감 있는 코인 질감. 단색 원보다 실물 코인 연상.
+- **size variant**: 14(pill 내부), 16(인라인 텍스트 옆), 20(float-up 단독) 3종 지원.
+  UX Flow 스펙 "최소 2종" 충족, 14는 rBestBadge pill 내부 타이트한 공간 대응.
+
+### 인터페이스
+
+```tsx
+interface CoinIconProps {
+  size?: 14 | 16 | 20  // default: 16
+  style?: React.CSSProperties
+}
+```
+
+### 구현 의사코드
+
+```tsx
+// src/components/result/CoinIcon.tsx
+export function CoinIcon({ size = 16, style }: CoinIconProps) {
+  // gradient id를 size별로 분리 — 동일 페이지에 여러 크기 공존 시 충돌 방지
+  const gradId = `coin-grad-${size}`
+  
+  return (
+    <svg
+      width={size}
+      height={size}
+      viewBox="0 0 20 20"
+      fill="none"
+      aria-label="코인"
+      role="img"
+      style={{ display: 'inline-block', flexShrink: 0, ...style }}
+    >
+      <defs>
+        <radialGradient id={gradId} cx="35%" cy="30%" r="65%">
+          <stop offset="0%"   stopColor="#FFE08A" />  {/* 하이라이트 */}
+          <stop offset="55%"  stopColor="#D4A843" />  {/* vb-accent */}
+          <stop offset="100%" stopColor="#8B7332" />  {/* vb-accent-dim */}
+        </radialGradient>
+      </defs>
+      {/* 코인 본체 — 타원으로 원근감 표현 */}
+      <ellipse cx="10" cy="10.5" rx="9" ry="8" fill={`url(#${gradId})`} />
+      {/* 상단 하이라이트 — 광원 반사 질감 */}
+      <ellipse cx="9" cy="8" rx="4" ry="2.5" fill="rgba(255,255,255,0.25)" />
+    </svg>
+  )
+}
+```
+
+---
+
+## 2. NewRecordBadge 수정 (pill 재설계)
+
+### 변경 전/후 비교
+
+| 항목 | 변경 전 | 변경 후 |
+|---|---|---|
+| 형태 | 박스형 (borderRadius 6, 좌측 골드 세로 바) | pill (borderRadius 999, 전체 골드 border) |
+| 텍스트 구조 | 2줄 수직: "NEW RECORD" / "PERSONAL BEST" | 1줄 수평: "🏆 PERSONAL BEST" + "+1" + CoinIcon(14) |
+| backgroundColor | `#18181b` | `transparent` |
+| border | `rgba(255,255,255,0.1)` 전체 | `1px solid var(--vb-accent)` |
+| padding | `10px 14px 10px 17px` | `4px 12px` |
+| 배치 컨텍스트 | 별도 div (marginTop 14, 점수 카드 내부) | Hero 카드 divider 아래, 중앙 정렬 인라인 |
+
+### 설계 결정
+- Pencil 노드 `PjMOx` 스펙 직접 반영: `cornerRadius 999`, `stroke $vb-accent`, `fill transparent`, `padding [4,12]`
+- 2줄 → 1줄: Hero 카드 내 수직 공간 절약. 배지는 "짧고 직관적"이어야 함 (UX Flow 리디자인 노트).
+- 기존 `nr-bar-grow`, `nr-content-slide-in` 키프레임 → 불필요 (좌측 세로 바 삭제). `nr-badge-fade-in`만 유지.
+
+### 구현 의사코드
+
+```tsx
+// src/components/result/NewRecordBadge.tsx
+import { CoinIcon } from './CoinIcon'
+
+export function NewRecordBadge() {
+  return (
+    <div
+      role="status"
+      aria-label="개인 최고 기록 달성"
+      aria-live="polite"
+      style={{
+        display: 'inline-flex',
+        alignItems: 'center',
+        gap: 6,
+        padding: '4px 12px',
+        borderRadius: 999,
+        border: '1px solid var(--vb-accent)',
+        backgroundColor: 'transparent',
+        animation: 'nr-badge-fade-in 300ms ease-out both',
+      }}
+    >
+      <span style={{
+        fontFamily: 'var(--vb-font-score)',
+        fontSize: 11,
+        fontWeight: 700,
+        color: 'var(--vb-accent)',
+        letterSpacing: 1.5,
+      }}>
+        🏆 PERSONAL BEST
+      </span>
+      <span style={{
+        fontFamily: 'var(--vb-font-score)',
+        fontSize: 11,
+        fontWeight: 700,
+        color: 'var(--vb-accent)',
+      }}>
+        +1
+      </span>
+      <CoinIcon size={14} />
+    </div>
+  )
+}
+```
+
+> **주의**: `nr-badge-fade-in` 키프레임이 `src/index.css`에 정의되어 있는지 확인 필수.
+> 없을 경우 `animation` 속성 제거하고 `opacity: 1` 정적 표시로 대체 (기능 우선).
+> 기존 `nr-bar-grow`, `nr-content-slide-in` 키프레임은 `src/index.css`에서 삭제 가능 (더 이상 미사용).
+
+---
+
+## 3. CoinRewardBadge 수정
+
+### 변경 내용
+- `🪙 +{amount} 코인 획득!` → inline-flex row: `<CoinIcon size={16} /> +{amount} 코인 획득!`
+- 루트 div에 `display: 'flex', alignItems: 'center', gap: 6` 추가
+
+```tsx
+// 변경 전
+🪙 +{amount} 코인 획득!
+
+// 변경 후
+<div style={{ display: 'flex', alignItems: 'center', gap: 6 }}>
+  <CoinIcon size={16} />
+  <span>+{amount} 코인 획득!</span>
+</div>
+```
+
+---
+
+## 4. PointExchangeButton 수정
+
+### 변경 내용
+- 버튼 내부: `display: 'flex', alignItems: 'center', justifyContent: 'center', gap: 6` 추가
+- 라벨 텍스트: `🪙 ${COIN_EXCHANGE_AMOUNT}코인 → ...` → `<CoinIcon size={16} /> ${COIN_EXCHANGE_AMOUNT}코인 → ...`
+
+```tsx
+// 변경 전 (단순 문자열)
+{isProcessing ? '교환 중...' : `🪙 ${COIN_EXCHANGE_AMOUNT}코인 → ...`}
+
+// 변경 후 (flex 컨테이너)
+<button style={{ ..., display: 'flex', alignItems: 'center', justifyContent: 'center', gap: 6 }}>
+  {isProcessing ? '교환 중...' : (
+    <>
+      <CoinIcon size={16} />
+      <span>{COIN_EXCHANGE_AMOUNT}코인 → {COIN_EXCHANGE_AMOUNT}포인트 교환</span>
+    </>
+  )}
+</button>
+```
+
+---
+
+## 5. ResultPage 전체 레이아웃 리디자인
+
+### 섹션 구조 (Hero / Stats / CTA 3계층)
+
+```
+[A] GAME OVER 헤더
+    └─ paddingTop: 20, textAlign: center
+    └─ marginBottom: 12  ← spacerHeaderHero (12px)
+
+[B] Hero 카드 (rScoreCard)
+    margin: 0 20px, padding: 24, cornerRadius: 12
+    ├─ FINAL SCORE 레이블 (11px, vb-text-dim, letterSpacing 3, Barlow)
+    ├─ 점수 숫자 (64px / weight 900, vb-text, Barlow)
+    ├─ stageRow (marginTop 8, display flex, justifyContent space-between)
+    │   ├─ "Stage {stage}" (12px, vb-text-dim, Space Grotesk)
+    │   └─ inline-flex: <CoinIcon size={16}/> "{coinBalance}개" (12px, vb-accent)
+    └─ isNewBest 시:
+        ├─ divider (borderTop: 1px solid vb-border, margin: 16px 0 12px)
+        └─ 중앙 정렬 row: <NewRecordBadge />
+    └─ marginBottom: 16  ← spacerHeroStats (16px)
+
+[C] Stats 카드 (rComboCard + rRankCard 통합)
+    margin: 0 20px, padding: 16, cornerRadius: 12
+    ├─ COMBO STATS 타이틀 (10px, vb-text-dim, letterSpacing 3)
+    ├─ 3열 stats row (marginTop 12, justifyContent space-between)
+    │   ├─ BEST COMBO / 값
+    │   ├─ MULTIPLIER / 값
+    │   └─ COMBO BONUS / 값
+    ├─ statsDivider (borderTop: 1px solid vb-border, margin: 12px 0 0)
+    └─ 랭킹 3행 (Daily/Monthly/Season)
+        각 행: padding 14px 16px, borderBottom 사이 구분
+        마지막 행 borderBottom 없음
+    └─ marginBottom: 16  ← spacerStatsAd (16px)
+
+[D] 광고 placeholder
+    margin: 0 20px, height: 96, cornerRadius: 8
+    └─ marginBottom: 16  ← spacerAdCta (16px)
+
+[E] CTA 섹션 (rBtnArea)
+    marginTop: 'auto', padding: '8px 20px 32px'
+    gap: 10 (flex column)
+    ├─ <PointExchangeButton />
+    ├─ 광고 로딩 중 텍스트 (adLoading && !adDone)
+    ├─ PLAY AGAIN 버튼 (height: 54px)  ← 기존 padding 16px 0 → 명시적 height 54
+    └─ View Rankings 버튼
+```
+
+### 루트 gap 제거 전략
+
+**현재 방식**: 각 카드 `margin: '12px 20px 0'` 또는 `margin: '16px 20px 0'`  
+**변경 방식**: 루트 컨테이너 gap 없음. 각 섹션에 `marginBottom` 명시 + 수평 margin은 각 섹션 자체에 선언
+
+```
+선택 근거: Pencil 노드 uAYzL gap 제거 지침 (이슈 본문).
+CSS gap 대신 marginBottom 개별 지정 → CTA의 marginTop: 'auto' 동작 보장.
+gap 방식은 flex 자식 모두에 간격을 주므로 마지막 요소 뒤에도 불필요 간격 생김.
+```
+
+### PLAY AGAIN 버튼 height 변경
+
+```tsx
+// 변경 전
+padding: '16px 0',
+
+// 변경 후 (명시적 height, padding 제거로 일관성)
+height: 54,
+padding: 0,
+```
+
+### coin-float-up 이모지 교체
+
+```tsx
+// 변경 전
++{coinReward} 🪙
+
+// 변경 후 (inline-flex)
+<div className="coin-float-up" style={{ ..., display: 'flex', alignItems: 'center', gap: 4 }}>
+  +{coinReward} <CoinIcon size={20} />
+</div>
+```
+
+> 기존 `transform: 'translateX(-50%)'`는 `className="coin-float-up"` CSS에 이미 포함되어 있거나
+> inline style로 선언됨 — 현재 코드 확인 후 유지.
+> `coin-float-up` CSS 애니메이션은 변경 없음.
+
+---
+
+## 삭제 대상 (구 코드 정리)
+
+| 삭제 대상 | 위치 | 대체 |
+|---|---|---|
+| 코인 잔액 독립 카드 div (`[v0.4] 코인 잔액 표시`) | ResultPage.tsx | Hero 카드 stageRow 우측으로 통합 |
+| 랭킹 독립 카드 div (`랭킹 리스트`) | ResultPage.tsx | Stats 카드 하단으로 통합 |
+| `<div style={{ marginTop: 14 }}><NewRecordBadge /></div>` | ResultPage.tsx | divider + `<div style={{ display:'flex', justifyContent:'center' }}>` 구조로 교체 |
+| `nr-bar-grow`, `nr-content-slide-in` 키프레임 | src/index.css | NewRecordBadge pill 구조에서 미사용 → 삭제 (다른 컴포넌트 미사용 확인 후) |
+
+---
+
+## 기능 보존 체크리스트 (변경 없는 항목)
+
+- [ ] 광고 완시청 → `CoinRewardBadge` + `coin-float-up` 표시 (`coinReward` 상태 유지)
+- [ ] `isNewBest` → PERSONAL BEST pill 표시 + `addCoins(1,'record_bonus')` 호출
+- [ ] `PointExchangeButton` disabled 상태 (`coinBalance < 10`) 및 비활성 이유 텍스트
+- [ ] `adLoading && !adDone` → PLAY AGAIN 비활성(회색), "광고 로딩 중..." 텍스트 표시
+- [ ] `handleExchange` → `grantCoinExchange()` → `addCoins(-10,...)` 흐름 변경 없음
+- [ ] toast 3초 자동 닫힘 로직 변경 없음
+- [ ] 점수 제출 (`submitScore`) + `prevBestRef` 패턴 변경 없음
+- [ ] `slide-up 0.5s ease-out` 페이지 진입 애니메이션 유지
+
+---
+
+## 구현 순서 권장
+
+```
+1. CoinIcon.tsx 생성 (의존 없음, 최우선)
+2. NewRecordBadge.tsx 수정 (CoinIcon import)
+3. CoinRewardBadge.tsx 수정 (CoinIcon import)
+4. PointExchangeButton.tsx 수정 (CoinIcon import)
+5. ResultPage.tsx 수정 (레이아웃 전체 재구성, 위 4개 import)
+6. src/index.css 정리 (nr-bar-grow, nr-content-slide-in 삭제, nr-badge-fade-in 존재 확인)
+```
+
+---
+
+## 주의사항
+
+### 컴포넌트 경계
+- `CoinIcon`은 현재 `src/components/result/`에 배치. GamePage/MainPage 확장은 별도 이슈.
+- `NewRecordBadge` 파일명 유지 → `ResultPage.tsx` import 경로 변경 불필요.
+
+### CSS 의존성 확인 필요
+- `nr-badge-fade-in` — 현재 `src/index.css` 또는 `NewRecordBadge` 내 정의 여부 확인.
+  NewRecordBadge 현재 코드: `animation: 'nr-badge-fade-in 300ms ease-out both'` 참조 중.
+  → 없으면 `@keyframes nr-badge-fade-in { from { opacity: 0 } to { opacity: 1 } }` 추가 (index.css).
+
+### Stats 카드 내 랭킹 패딩 처리
+- 랭킹 행은 카드 자체 padding(16px)이 아닌, 행별 `padding: '14px 16px'` 사용.
+- statsDivider는 카드 내부에서 전폭 구분선이 되어야 하므로,
+  Stats 카드 `padding` 제거 + 내부 섹션별 padding 적용 방식 또는
+  `margin: '0 -16px'`으로 divider를 카드 전폭으로 확장하는 방식 중 선택.
+  **권장**: 후자 (`margin: '12px -16px 0'`으로 divider 전폭 확장) — 카드 padding을 16 유지하며 구분선만 전폭.

--- a/docs/ux-flow.md
+++ b/docs/ux-flow.md
@@ -5,6 +5,7 @@
 - PRD: prd.md (v0.4)
 - 참조 문서: docs/architecture.md, docs/ui-spec.md
 - 생성일: 2026-04-17
+- 최종 수정: 2026-04-18 (UX_REFINE — S04 코인 아이콘 이모지 대체 지침 추가)
 
 ---
 
@@ -268,50 +269,56 @@ stateDiagram-v2
 
 ---
 
-### S04 — ResultPage
+### S04 — ResultPage (리디자인)
 
 #### 와이어프레임
 
+섹션을 Hero / Stats / CTA 3계층으로 명확히 구분한다. 기존 카드 나열 구조에서 정보 위계 기반 그룹핑으로 전환.
+
+> **코인 아이콘 규칙 (ResultPage 전역)**: 와이어프레임 내 `[CoinIcon]`으로 표기된 모든 자리는 🪙 이모지가 아닌 커스텀 디자인 CoinIcon 컴포넌트를 사용한다. 이모지 금지. size variant 최소 2종(16/20px 또는 20/24px 중 designer 결정). 색/스타일은 디자인 가이드의 골든 엑센트 방향에 맞춰 designer가 결정.
+
 ```
 ┌──────────────────────────────┐
-│  GAME OVER (레드, 추적)      │  ← 상단 헤더
+│  GAME OVER  (레드, 추적)     │  ← [A] 헤더 — 상단 고정, padding-top 20
 │                              │
-│  ┌──────────────────────┐    │
-│  │  FINAL SCORE         │    │  ← 점수 카드
-│  │  [점수 64px]         │    │
-│  │  Stage N             │    │
-│  │  [NEW PERSONAL BEST] │    │    최고기록 갱신 시 배지
-│  │  🏆 최고기록! 🪙 +1  │    │
-│  └──────────────────────┘    │
+│ ┌──── [B] HERO 섹션 ───────┐ │  ← vb-surface 카드, padding 24
+│ │  FINAL SCORE             │ │    cornerRadius 12, border vb-border
+│ │  ████ N ████  (64px)     │ │    점수 수치가 화면 최대 시각 요소
+│ │  Stage N    [CoinIcon] N개│ │    ← 스테이지 + 코인 잔액을 같은 행 양끝
+│ │  ─────────────────────── │ │    ← divider (isNewBest=true 시만 표시)
+│ │  🏆 PERSONAL BEST  +1[CoinIcon]│ │  ← isNewBest 시: 골든 pill (인라인)
+│ └──────────────────────────┘ │
 │                              │
-│  보유 코인          🪙 N개   │  ← 코인 잔액 카드
+│ ┌──── [C] STATS 섹션 ──────┐ │  ← vb-surface 카드, padding 16
+│ │  COMBO STATS             │ │    세 열 가로 배치 유지
+│ │  BEST  │ MULTI │  BONUS  │ │
+│ │   N    │  xN   │   +N    │ │
+│ ├──────────────────────────┤ │    ← 구분선 (border-top vb-border)
+│ │  Daily     #N            │ │    랭킹 3행 인라인 (기존 별도 카드 → 통합)
+│ │  Monthly   #N            │ │
+│ │  Season    #N            │ │
+│ └──────────────────────────┘ │
 │                              │
-│  ┌──────────────────────┐    │
-│  │  COMBO STATS         │    │  ← 콤보 스탯 카드
-│  │  BEST COMBO │ MULTIPLIER │ COMBO BONUS │
-│  │  N회        │  xN   │  +N    │
-│  └──────────────────────┘    │
+│  [광고 placeholder 96px]     │  ← [D] 광고 영역 (독립 유지)
 │                              │
-│  ┌──────────────────────┐    │
-│  │  Daily     #N        │    │  ← 랭킹 카드 (3행)
-│  │  Monthly   #N        │    │
-│  │  Season    #N        │    │
-│  └──────────────────────┘    │
-│                              │
-│  [광고 placeholder 96px]     │
-│                              │
-│  [🪙 10코인 → 10포인트 교환] │  ← PointExchangeButton
-│  (잔액 부족 시 disabled + 안내)
-│                              │
-│  [광고 로딩 중... 텍스트]    │  ← adLoading AND !adDone 시
-│                              │
-│  [PLAY AGAIN]                │  ← adDone=true 시 활성
-│  [View Rankings]             │
+│ ┌──── [E] CTA 섹션 ────────┐ │  ← gap 없는 스택. padding 0 0 32 0
+│ │  [[CoinIcon] 10코인→10포인트] │ │  PointExchangeButton (보조, 테두리)
+│ │  [광고 로딩 중...]        │ │    adLoading AND !adDone 시만 표시
+│ │  ████ PLAY AGAIN ████    │ │    Primary CTA (골든 채움, 높이 강조)
+│ │  [ View Rankings ]       │ │    보조 CTA (투명 + 테두리)
+│ └──────────────────────────┘ │
 └──────────────────────────────┘
 [CoinRewardBadge: fixed bottom 80, 3초 auto-dismiss]
-[+N🪙 float-up: fixed bottom 120, coin-float-up 애니메이션]
+[+N[CoinIcon] float-up: fixed bottom 120, coin-float-up 애니메이션]
 [토스트: fixed bottom 80, 3초 자동 닫힘]
 ```
+
+**섹션별 간격 규칙:**
+- 헤더(A) → Hero(B): gap 12
+- Hero(B) → Stats(C): gap 16 (섹션 전환 강조)
+- Stats(C) → 광고(D): gap 16
+- 광고(D) → CTA(E): gap 16
+- CTA 내부(ExchangeButton → PLAY AGAIN → View Rankings): gap 10 유지
 
 #### 인터랙션
 
@@ -320,7 +327,7 @@ stateDiagram-v2
 | 화면 진입 (마운트) | showAd() 자동 시작 | 리워드 광고 강제 시작 (스킵 불가) |
 | 광고 완시청 (userEarnedReward) | randomCoinReward() → addCoins(N,'ad_reward') | CoinRewardBadge + float-up 표시 |
 | 광고 스킵/실패 | setAdDone(true) | 코인 미지급, PLAY AGAIN 활성화 |
-| 최고기록 갱신 (score>prevBest) | addCoins(1,'record_bonus') | isNewBest=true → "🏆 최고기록! 🪙 +1" 배지 |
+| 최고기록 갱신 (score>prevBest) | addCoins(1,'record_bonus') | isNewBest=true → Hero 카드 내 PERSONAL BEST pill 표시 |
 | 교환 버튼 탭 (balance≥10) | grantCoinExchange() → addCoins(-10,'toss_points_exchange') | "🎉 10포인트 지급됐어요!" 토스트 |
 | 교환 실패 | showToastMsg('교환 중 오류...') | 에러 토스트 |
 | PLAY AGAIN 탭 (adDone=true) | resetGame() → onPlayAgain() | MainPage IDLE |
@@ -332,7 +339,7 @@ stateDiagram-v2
 |------|------|------|
 | 광고 로딩 중 | adLoading=true AND adDone=false | "광고 로딩 중..." 텍스트, PLAY AGAIN 비활성(회색) |
 | 광고 완료 | adDone=true | PLAY AGAIN 활성(골든), CoinRewardBadge 표시(있으면) |
-| 최고기록 갱신 | isNewBest=true | NEW PERSONAL BEST 배지 + 🏆 +1 표시 |
+| 최고기록 갱신 | isNewBest=true | Hero 카드 내 divider + 골든 pill "🏆 PERSONAL BEST +1[CoinIcon]" 인라인 표시 |
 | 교환 가능 | coinBalance≥10 | PointExchangeButton 활성(골든 테두리) |
 | 교환 불가 | coinBalance<10 | PointExchangeButton disabled + "코인 10개가 필요합니다 (현재 N개)" |
 | 교환 처리 중 | isProcessing=true | "교환 중..." opacity 0.6 |
@@ -343,7 +350,32 @@ stateDiagram-v2
 |------|------|------|
 | 페이지 진입 | slide-up 0.5s ease-out | 게임오버 오버레이에서 결과 화면으로 부드러운 전환 |
 | CoinRewardBadge | 고정 표시 3초 → onDismiss | 코인 획득 명확한 피드백, 자동 소멸 |
-| +N🪙 float-up | coin-float-up CSS 애니메이션 | 광고 시청 보상 즉각 시각화 |
+| +N[CoinIcon] float-up | coin-float-up CSS 애니메이션 | 광고 시청 보상 즉각 시각화 |
+
+#### 리디자인 노트
+
+기능 목록 (모두 유지 필수):
+- rGoText: GAME OVER 헤더
+- rFinalLabel + rFinalScore: 최종 점수
+- rStageLabel: 스테이지 번호
+- rBestBadge(rBestText + coinBestText): 최고기록 배지
+- rCoinCard(coinLabel2 + coinValue2): 보유 코인 잔액
+- rComboCard(rComboTitle + rCS1/CS2/CS3): 콤보 스탯
+- rRankCard(rR1/R2/R3): 일간/월간/시즌 랭킹
+- rAdPlaceholder: 광고 영역
+- rPointExBtn(rPointExBtnInner + rPointExNeededTxt): 교환 버튼
+- rPlayBtn(rPlayTxt): PLAY AGAIN
+- rViewBtn(rViewTxt): View Rankings
+- rCoinFloat(rCoinFloatText): 코인 플로트 애니메이션
+
+| 대상 (노드명) | 현재 문제 | 변경 지침 | 우선순위 |
+|---------------|----------|----------|----------|
+| 코인 아이콘 (ResultPage 전역) | ResultPage 내 모든 코인 표현에 🪙 이모지 사용 중 — 와이어프레임의 "Stage N [CoinIcon] N개", "+1[CoinIcon]" pill, "[CoinIcon] 10코인 → 10포인트" 버튼, "+N[CoinIcon] float-up" 등 | 🪙 이모지를 전부 커스텀 디자인 CoinIcon 컴포넌트로 대체. CoinIcon은 독립 컴포넌트로 별도 정의(이모지 금지). size variant 최소 2종: 16px(인라인 텍스트 옆, pill 내부용)와 20px(float-up, 단독 노출용) — 실제 variant는 designer가 16/20/24 중 택 2. 색/형태는 골든 엑센트(`--vb-accent` 계열) 방향에 맞춰 designer가 결정. 적용 범위: Hero 섹션 코인 잔액 행, PERSONAL BEST pill 내 "+1코인", CTA ExchangeButton 내 코인 표시, CoinRewardBadge, float-up 텍스트 | P0 |
+| rBestBadge (PjMOx) | 독립 박스 형태. `#c8ff001a` 연두빛 fill이 게임 톤(다크+골든)에서 이질적. "NEW PERSONAL BEST"와 "🏆 최고기록!" 두 줄이 수직 나열되어 배지 같지 않고 주석 덩어리처럼 보임 | rScoreCard 내부 하단에 가로 분리선 추가 후, 분리선 아래 단일 행 인라인 pill로 재배치. fill을 `transparent`, stroke를 `$vb-accent`로 유지하되 cornerRadius를 pill 수준(999)으로 변경. 두 텍스트(rBestText + coinBestText)를 한 행 가로 배치(gap 8, layout horizontal). rBestText 내용: "🏆 PERSONAL BEST", coinBestText 내용: "+1[CoinIcon]" — 짧고 직관적. 배지 전체 padding을 [4, 12]로 조임 | P0 |
+| rCoinCard (Fu38h) | rScoreCard와 별도 독립 카드로 분리됨. 코인 잔액이 점수/스테이지와 문맥 단절. 카드 하나 분량의 공간을 단 두 텍스트가 독점 | rCoinCard를 rScoreCard 하단으로 통합. rStageLabel 행을 가로 양끝 레이아웃(justifyContent: space_between)으로 전환해 "Stage N"(좌)과 "[CoinIcon] N개"(우)를 한 행에 배치. coinLabel2("보유 코인") 텍스트는 제거(coinValue2의 CoinIcon이 맥락 충분히 전달). rCoinCard 독립 카드는 삭제 | P0 |
+| rComboCard + rRankCard (NY75d + O5sww) | 콤보 스탯과 랭킹이 각각 독립 카드. 두 카드 모두 "게임 결과 상세 정보"라는 같은 목적인데 시각적으로 분산됨 | rComboCard와 rRankCard를 단일 Stats 카드로 통합. 내부 구조: 상단에 COMBO STATS 섹션(기존 rComboTitle + rComboStats 3열 유지), 그 아래 border-top 구분선 추가, 구분선 아래에 rR1/R2/R3 랭킹 3행 배치. 카드 padding은 0으로 두고 내부 각 섹션에 16px padding 적용 (구분선이 카드 전폭에 걸리도록) | P1 |
+| rBtnArea (UxXnX) | PLAY AGAIN, View Rankings, PointExchangeButton이 gap 10px 균일 나열. PLAY AGAIN이 Primary CTA인데 다른 버튼과 시각적 비중 차이 없음. 상단 패딩 없이 광고 영역 바로 아래 이어져 CTA 섹션 구분 불명확 | rBtnArea padding-top을 4에서 8로 증가. PLAY AGAIN 버튼(rPlayBtn) height를 명시적으로 54px로 키워 Primary CTA 비중 강화. 버튼 순서 유지(ExchangeButton → 광고로딩텍스트 → PLAY AGAIN → View Rankings). 다른 요소 스타일 변경 없음 | P1 |
+| 전체 카드 간격 (uAYzL gap) | gap 12px 균일 적용으로 Hero/Stats/CTA 섹션 경계 없음. 모든 카드가 동등한 비중으로 나열됨 | uAYzL 루트 gap을 제거하고 각 섹션 사이 margin-bottom을 개별 지정: Hero 카드 아래 16px, Stats 카드 아래 16px, 광고 아래 16px. 섹션 내부 요소 간격(콤보-랭킹 구분선 등)은 각 컴포넌트 내부에서 처리 | P2 |
 
 ---
 
@@ -406,7 +438,7 @@ stateDiagram-v2
 | S01 | MainPage | SCREEN | P0 | 코인 잔액 바 [v0.4] 포함 |
 | S02 | GamePage | SCREEN | P0 | StageArea 5개 상태 모두 |
 | S03 | GameOverOverlay | SCREEN | P0 | 바텀 시트 + blur backdrop |
-| S04 | ResultPage | SCREEN | P0 | 코인 흐름 전체 포함 [v0.4] |
+| S04 | ResultPage | SCREEN | P0 | 코인 흐름 전체 포함 [v0.4] — 리디자인 노트 참조 |
 | S05 | RankingPage | SCREEN | P1 | 3개 탭 + 에러/빈 상태 |
 | C01 | ButtonPad | COMPONENT | P0 | IDLE/SHOWING/INPUT/CLEARING/RESULT 5상태 |
 | C02 | ComboTimer | COMPONENT | P0 | normal/warning/danger 3페이즈 |
@@ -417,3 +449,4 @@ stateDiagram-v2
 | C07 | PointExchangeButton | COMPONENT | P1 | 활성/비활성/처리중 3상태 |
 | C08 | FloatingScore | COMPONENT | P1 | x1~x5+ 색상 및 크기 분기 |
 | C09 | RevivalButton | COMPONENT | P1 | 표시(활성/처리중) / 미표시 |
+| C10 | CoinIcon | COMPONENT | P0 | size variant 최소 2종(16/20px 등), 이모지 대체 전용 컴포넌트 |

--- a/trd.md
+++ b/trd.md
@@ -1,6 +1,7 @@
 # 기억력배틀 TRD v0.4
 
 > 변경 이력
+> - v0.4.4 (2026-04-18): ResultPage 리디자인 (#129) — Hero/Stats/CTA 3계층 구조, CoinIcon 신규 컴포넌트, rCoinCard 삭제 → stageRow 통합, rComboCard+rRankCard → 단일 Stats 카드, NewRecordBadge 골든 pill 인라인.
 > - v0.4.3 (2026-04-16): architecture.md DESIGN_REVIEW_FAIL 수정 — useCoin.addCoins 2-param 확정(userId 내부 조회), GameOverOverlay 즉시 부활 경로 addCoins(-5,'revival') 명시.
 > - v0.4.2 (2026-04-16): 설계 문서 불일치 수정 — docs/game-logic.md: add_coins RPC 2-param→3-param atomic 버전 통일, revivalUsed=true 시 RevivalButton 미표시로 수정. docs/db-schema.md: add_coins RPC 정의 누락 추가.
 > - v0.4.1 (2026-04-16): docs/sdk.md 현행화 — grantCoinExchange 미구현 명시, grantDailyReward 삭제 예정 표기, granite.config icon/webViewProps 불일치 수정, 환경변수명 VITE_REWARD_AD_ID→VITE_REWARD_AD_GROUP_ID, VITE_BANNER_AD_ID→VITE_BANNER_AD_GROUP_ID 수정.
@@ -54,9 +55,11 @@ memory-battle/
 │   │   │   ├── BannerAd.tsx
 │   │   │   └── RewardAd.tsx
 │   │   └── result/                     # [v0.4] 게임오버 결과 서브 컴포넌트
-│   │       ├── CoinRewardBadge.tsx     # "🪙 +N 획득!" 피드백
+│   │       ├── CoinIcon.tsx            # [v0.4.4] SVG 코인 아이콘 (size 14/16/20, radialGradient)
+│   │       ├── CoinRewardBadge.tsx     # "코인 +N 획득!" 피드백 (CoinIcon(16) 사용)
+│   │       ├── NewRecordBadge.tsx      # [v0.4.4] 골든 pill 인라인 (🏆 PERSONAL BEST + "+1" + CoinIcon(14))
 │   │       ├── RevivalButton.tsx       # 부활 버튼 (5코인)
-│   │       └── PointExchangeButton.tsx # 토스포인트 교환 버튼 (10코인)
+│   │       └── PointExchangeButton.tsx # 토스포인트 교환 버튼 (CoinIcon(16) 사용)
 │   ├── hooks/
 │   │   ├── useGameEngine.ts    # 핵심 게임 로직 (깜빡임 속도·타이머·콤보 통합)
 │   │   ├── useRanking.ts       # Supabase 랭킹 연동
@@ -452,18 +455,53 @@ interface GameStore {
 - GameOverOverlay (v0.3.2): 게임오버 시 backdrop blur + 바텀 패널 슬라이드업. shake 애니메이션. 탭으로 결과 화면 전환 (자동 전환 X). `position: absolute`(v0.3.2-fix: fixed→absolute). 패널 상단: 핸들바(32×4px) + 경고 아이콘(⚠ 48×48px 원형) + "GAME OVER" 타이틀(Barlow Condensed 13px, letter-spacing 3px)
 - **[v0.4] GameOverOverlay 즉시 부활**: balance≥5 AND !revivalUsed 조건에서 즉시 부활 버튼 표시. 탭 시 `addCoins(-5, 'revival')` → `store.revive()` 호출 → SHOWING 복귀 (ResultPage 미진입). revivalUsed=true 설정으로 판당 1회 보장.
 
-### ResultPage ⚠️ v0.4 변경
-- 이번 점수 + 최고 기록 갱신 여부
-- 최고 도달 스테이지
-- 풀콤보 달성 횟수 + 최고 콤보 스택 + 콤보 보너스 점수
-- 랭킹 진입 시: 일간/월간/시즌 순위 각각 표시
-- 리워드 광고 자동 시작 (강제, 스킵 불가)
-- **[v0.4] CoinRewardBadge**: 완시청 → "🪙 +N 코인 획득!" (최고기록 시 "🏆 +1 코인" 추가)
-- **[v0.4] RevivalButton**: 5코인 소모, 비활성 이유 텍스트 포함
-- **[v0.4] PointExchangeButton**: 10코인→10포인트, 비활성 이유 텍스트 포함
-- **[v0.4] 현재 코인 잔액** 상시 표시
+### ResultPage ⚠️ v0.4.4 리디자인 (#129)
+
+레이아웃 3계층 구조: **Hero 카드 → Stats 카드 → CTA 영역** (루트 gap 제거 → spacer div 기반 간격).
+
+**[A] GAME OVER 헤더** — paddingTop 20, 텍스트 중앙 정렬 (GAME OVER, letterSpacing 4)
+
+**[B] Hero 카드 (rScoreCard)** — `margin: '0 20px 16px'`, padding 24
+- FINAL SCORE 레이블 + 점수 (64px, Barlow Condensed)
+- **stageRow**: Stage N (좌) ↔ CoinIcon(16) + 잔액(우) — space-between (v0.4.4: rCoinCard 삭제, stageRow 통합)
+- isNewBest 시: divider + **NewRecordBadge** pill (center flex)
+
+**[C] Stats 카드** — `margin: '0 20px 16px'`, borderRadius 12, overflow hidden (v0.4.4: rComboCard + rRankCard 통합)
+- COMBO STATS 섹션 (padding 16): BEST COMBO / MULTIPLIER / COMBO BONUS 3열
+- **statsDivider**: `borderTop: '1px solid var(--vb-border)'` (margin 없음 — 카드 outer padding 불필요)
+- 랭킹 3행 (Daily / Monthly / Season): padding '14px 16px', borderBottom
+
+**[D] 광고 placeholder** — `margin: '0 20px 16px'`, height 96, borderRadius 8
+
+**[E] CTA 영역 (rBtnArea)** — `marginTop: 'auto'`, padding '8px 20px 32px', gap 10
+- **PointExchangeButton**: CoinIcon(16) + "N코인 → N포인트 교환"
+- 광고 로딩 중 안내 텍스트 (adLoading && !adDone)
+- **PLAY AGAIN 버튼**: height 54, adDone 시 활성 (vb-accent 배경, boxShadow)
+- View Rankings 버튼: border outline, 높이 자동 (padding 14px 0)
+
+**오버레이/피드백**
+- coin-float-up: `position: fixed, bottom: 120`, CoinIcon(20), z-index 201
+- CoinRewardBadge: 광고 완시청 후 3초 자동 dismiss, CoinIcon(16)
+- 토스트: `position: fixed, bottom: 80`, z-index 200
+
+**신규 컴포넌트** (v0.4.4): `src/components/result/CoinIcon.tsx`
+- SVG ellipse 2개 (본체 radialGradient #FFE08A→#D4A843→#8B7332, 하이라이트 rgba(255,255,255,0.25))
+- viewBox 0 0 20 20, size prop: 14 | 16 | 20
+- gradient id: `coin-grad-{size}` (동일 페이지 크기별 충돌 방지)
+- 이모지 🪙 대체 목적
+
+**NewRecordBadge** (v0.4.4 변경): 박스 UI 제거 → 골든 pill 인라인
+- `borderRadius: 999`, `border: '1px solid var(--vb-accent)'`, `backgroundColor: transparent`
+- `animation: 'nr-badge-fade-in 300ms ease-out both'`
+- 내부: "🏆 PERSONAL BEST" (letterSpacing 1.5) + "+1" + CoinIcon(14) — inline-flex, gap 6
+
+- ~~rCoinCard 독립 카드~~ (v0.4.4 삭제 → stageRow 우측 통합)
+- ~~rComboCard / rRankCard 분리 카드~~ (v0.4.4 삭제 → 단일 Stats 카드 통합)
+- ~~NewRecordBadge 박스~~ (v0.4.4 → 골든 pill 인라인)
+- ~~리워드광고 RevivalButton~~ (GameOverOverlay로 이동, ResultPage 미표시)
 - ~~"10포인트 지급!" 메시지~~ (daily_reward 방식 폐지)
-- 광고 종료 후 **다시하기** 버튼 활성화 (횟수 제한 없음)
+
+광고 종료 후 **PLAY AGAIN** 버튼 활성화 (횟수 제한 없음)
 
 ### RankingPage
 - 탭: 일간 / 월간 / 시즌


### PR DESCRIPTION
## Summary

#129 ResultPage 리디자인이 머지(commit 8813251)됐으나 하네스 훅 문제로 `trd.md` 수정이 구현 루프 내에서 차단됐던 관계로 관련 문서 3건이 누락됐음. 이 PR은 그 문서 현행화를 담당.

**코드 변경 없음. 문서 전용.**

### 변경 파일

- `trd.md` — v0.4.4 이력 추가, §2에 `CoinIcon.tsx` 추가, §7 ResultPage 3계층 스펙 전면 재작성
- `docs/ux-flow.md` — S04 ResultPage 리디자인 섹션에 와이어프레임·리디자인 노트 6건·CoinIcon 컴포넌트 지침 추가
- `docs/bugfix/#129-result-redesign.md` — 구현 계획 파일 보존 (신규)

## Test plan

- [x] `npm test` — 394건 전부 PASS (#131 테스트 회귀 수정 이후)
- [x] 문서 링크/형식 검증 (git diff)
- [x] `trd.md` §7과 실제 `ResultPage.tsx` 구현 일치 확인

Related to #129