### PR TITLE
chore(harness): enable worktree isolation

### DIFF
--- a/.claude/harness.config.json
+++ b/.claude/harness.config.json
@@ -4,5 +4,6 @@
   "lint_command": "npx eslint . --max-warnings 0",
   "build_command": "npx tsc --noEmit",
   "second_reviewer": "gemini",
-  "second_reviewer_model": "gemini-2.5-flash"
+  "second_reviewer_model": "gemini-2.5-flash",
+  "isolation": "worktree"
 }

--- a/.gitignore
+++ b/.gitignore
@@ -35,3 +35,6 @@ screenshots/
 
 # 테스트 커버리지
 coverage/
+
+# harness worktrees
+.worktrees/


### PR DESCRIPTION
## Summary
- 하네스 impl 루프 worktree 격리 모드 설정 활성화
- `.worktrees/` 디렉토리를 .gitignore에 추가

## Context
impl 루프가 이미 `.worktrees/mb/issue-NNN/` 경로로 worktree를 만들어 작업 중. 설정 파일에 이를 명시적으로 선언하고 ignore 처리.