### PR TITLE
feat: #147-resultpage-rank-color-css-var (#147)

### DIFF
--- a/src/pages/ResultPage.tsx
+++ b/src/pages/ResultPage.tsx
@@ -284,7 +284,7 @@ export function ResultPage({ onPlayAgain, onGoRanking }: ResultPageProps) {
               fontFamily: 'var(--vb-font-score)',
               fontSize: 16,
               fontWeight: 900,
-              color: highlight ? 'var(--vb-accent)' : '#8b8b90',
+              color: highlight ? 'var(--vb-accent)' : 'var(--vb-text-mid)',
             }}>{rankDisplay(rank)}</div>
           </div>
         ))}


### PR DESCRIPTION
## Summary
ResultPage 랭킹행 비강조 색상 `#8b8b90` 매직 리터럴을 CSS 변수 `var(--vb-text-mid)`로 교체.

## Background
이슈 #147 원문은 `var(--vb-text-dim)` 사용을 지시했으나 CSS 실제 값 확인 결과:
- `--vb-text-dim: #505055` (이슈 주장과 다른 값)
- `--vb-text-mid: #8b8b90` ← `#8b8b90`과 정확히 일치

시각적 변화 없음 요건 충족을 위해 `--vb-text-mid` 사용 (이슈 스펙의 사실 오류 보정).

## Changes
- `src/pages/ResultPage.tsx` L287: `'#8b8b90'` → `'var(--vb-text-mid)'`

## Note
이전 PR #148이 close 상태에서 merge conflict로 종료되어 동일 branch 재활용하여 새 PR로 생성.

Closes #147